### PR TITLE
Usecase/email regex

### DIFF
--- a/examples/email_matching/.env.example
+++ b/examples/email_matching/.env.example
@@ -1,0 +1,1 @@
+OPENAI_API_KEY=sk-XXX

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -11,13 +11,13 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
 @monkey.patch
-def match_email(email: str, names: List[str]) -> Optional[str]:
+def match_email(email: str, names: List[str]) -> Optional[List[str]]:
     """
-    Examine the list of names and return the name that is most likely to correspond to the email address.
+    Examine the list of names and return all the names that are likely to correspond to the email address.
     The names array includes both first names and last names. Make sure to consider both the first and last name
     as unique values when searching for a match. Be very conservative in what you consider to be a match.
-    If there is no clear match, return an empty string. If there are multiple possible matches, return an empty string.
-    If there are multiple partial matches, return an empty string.
+    If there is one clear match, return a list with one name. If there are multiple clear matches, return a list with all the possible matches.
+    If there are no possible matches, return None.
     """
 
 
@@ -25,21 +25,39 @@ def match_email(email: str, names: List[str]) -> Optional[str]:
 def align_match_email() -> None:
 
     # 1:1 Matching
-    assert match_email("john.smith@gmail.com", ["John Smith"]) == "John Smith"
-    assert match_email("jsmith@google.com", ["John Smith"]) == "John Smith"
-    assert match_email("j.smith@google.com", ["John Smith"]) == "John Smith"
-    assert match_email("jasmith@google.com", ["John Smith"]) == "John Smith"
+    assert match_email("john.smith@gmail.com", ["John Smith"]) == ["John Smith"]
+    assert match_email("jsmith@google.com", ["John Smith"]) == ["John Smith"]
+    assert match_email("j.smith@google.com", ["John Smith"]) == ["John Smith"]
+    assert match_email("jasmith@google.com", ["John Smith"]) == ["John Smith"]
+    assert match_email("t.swift@yahoo.com", ["John Smith", "Taylor Swift", "Satia Swift", "Milton Swift"]) == ["Taylor Swift"]
+    
+    # 1: Many Matching
+    assert match_email("john.smith@gmail.com", ["John Smith", "Jen Smith"]) == ["John Smith"]
 
-    # 1 from Many Matching
-    assert match_email("john.smith@gmail.com", ["John Smith", "Jen Smith"]) == "John Smith"
+    # Multiple matches
+    assert match_email("jsmith@google.com", ["John Smith", "Ella Oakly", "George Bush", "Jaden Smith"]) == ["John Smith", "Jaden Smith"]
+    assert match_email("George@google.com", ["John Smith", "George Oakly", "George Bush", "Jaden Smith"]) == ["George Oakly", "George Bush"]
 
     # Return None because there are multiple possible matches
-    assert match_email("jsmith@gmail.com", ["John Smith", "Jen Smith"]) == ""
-    assert match_email("johnsmith@gmail.com", ["John Smith", "John Smith Jr."]) == ""
-    assert match_email("johnsmith123@gmail.com", ["John Smith", "John Smith III"]) == ""
-    assert match_email("bill@example.net", ["Bill Burr", "Bill"]) == ""
-    assert match_email("smith@example.co", ["Smith Sanders", "Jen Smith", "Smit Harris"]) == ""
+    assert not match_email("jsmith@gmail.com", ["John Smith", "Jen Smith"])
+    assert not match_email("johnsmith@gmail.com", ["John Smith", "John Smith Jr."])
+    assert not match_email("johnsmith123@gmail.com", ["John Smith", "John Smith III"])
+    assert not match_email("bill@example.net", ["Bill Burr", "Bill"])
+    assert not match_email("smith@example.co", ["Smith Sanders", "Jen Smith", "Smit Harris"])
 
+
+def wrap_match_email(email: str, names: List[str]) -> Optional[str]:
+    """Wrapper method to call `match_email` method multiple times."""
+
+    match = match_email(email, names)
+
+    if match:
+        match_revised = match_email(email, match)
+        if match_revised and len(match_revised) == 1:
+            return match_revised[0]
+        return None
+
+    return None
 
 # Example usage
 if __name__ == '__main__':
@@ -47,8 +65,8 @@ if __name__ == '__main__':
     align_match_email()
 
     print("Matching...")
-    match = match_email("ethan.brown@gmail.com", ["Ethan Brown", "John Smith", "Mary Johnson", "Eva Brown"])
+    match = wrap_match_email("ethan.brown@gmail.com", ["Ethan Brown", "John Smith", "Mary Johnson", "Eva Brown"])
     print(match)
 
-    match = match_email("ebrown@gmail.com", ["Ethan Brown", "Eva Brown"])
+    match = wrap_match_email("ebrown@gmail.com", ["Ethan Brown", "Eva Brown"])
     print(match)

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -38,7 +38,7 @@ def align_match_email() -> None:
     assert match_email("jsmith@google.com", ["John Smith", "Ella Oakly", "George Bush", "Jaden Smith"]) == ["John Smith", "Jaden Smith"]
     assert match_email("George@google.com", ["John Smith", "George Oakly", "George Bush", "Jaden Smith"]) == ["George Oakly", "George Bush"]
 
-    # Return None because there are multiple possible matches
+    # Return None because there are no possible matches
     assert match_email("rsunak@gmail.com", ["John Smith", "Jen Smith", "Emily Johnson"]) == None
     assert match_email("marcopolo@gmail.com", ["John Smith", "John Smith Jr.", "David Anderson"]) == None
     assert match_email("johnsmith123@gmail.com", ["Lando Norrs", "David Singh"]) == None

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -1,7 +1,7 @@
 import openai
 import os
 from dotenv import load_dotenv
-from typing import List
+from typing import List, Optional
 
 load_dotenv()
 
@@ -11,12 +11,13 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 
 
 @monkey.patch
-def match_email(email: str, names: List[str]) -> str:
+def match_email(email: str, names: List[str]) -> Optional[str]:
     """
     Examine the list of names and return the name that is most likely to correspond to the email address.
-    The names array includes both first and last names. Make sure to consider both the first and last name
-    as unique values when searching for a match. If two names have the same score, return an empty string.
-    Return an empty string if no match is found or if more than one name could be an email match.
+    The names array includes both first names and last names. Make sure to consider both the first and last name
+    as unique values when searching for a match. Be very conservative in what you consider to be a match.
+    If there is no clear match, return an empty string. If there are multiple possible matches, return an empty string.
+    If there are multiple partial matches, return an empty string.
     """
 
 

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -47,12 +47,16 @@ def align_match_email() -> None:
 
 
 def wrap_match_email(email: str, names: List[str]) -> Optional[str]:
-    """Wrapper method to call `match_email` method multiple times."""
+    """
+    Wrapper method to call `match_email` method multiple times.
+    For this particular use-case, the filter function (match_email) needs to be called atleast twice as GPT4 has quite a high False-Positive rate when working with longer lists of names.
+    Calling the filtering function twice worked well to reduce the final False-Positive rate to a acceptable minimum
+    """
 
-    match = match_email(email, names)
+    match = match_email(email, names) # first call, may include false-positives
 
     if match:
-        match_revised = match_email(email, match)
+        match_revised = match_email(email, match) # second call to remove false positives
         if match_revised and len(match_revised) == 1:
             return match_revised[0]
 

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -1,0 +1,42 @@
+import openai
+import os
+from dotenv import load_dotenv
+from typing import List
+
+from monkey_patch.monkey import Monkey as monkey
+
+load_dotenv()
+
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
+
+
+@monkey.patch
+def match_email(email: str, names: List[str]) -> str:
+    """
+    Examine the list of names and return the name that is most likely to correspond to the email address.
+    Return an empty string if no match is found.
+    """
+
+@monkey.align
+def align_match_email() -> None:
+    assert match_email("john.smith@gmail.com", ["John Smith"]) == "John Smith"
+
+
+@monkey.patch
+def summarize_text_extra(input: str, instructions: str) -> str:
+    """
+    Use the input argument and apply the instructions argument for how to assemble into response.
+    """
+
+
+# Example usage
+if __name__ == '__main__':
+    print("Aligning...")
+    # align_match_email()
+
+    print("Matching...")
+    # match = match_email("ethan.brown@gmail.com", ["Ethan Brown", "John Smith", "Mary Johnson"])
+    # print(match)
+    print(openai.api_key)
+    summ = summarize_text_extra("This is a test", "Summarize the text")

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -55,7 +55,6 @@ def wrap_match_email(email: str, names: List[str]) -> Optional[str]:
         match_revised = match_email(email, match)
         if match_revised and len(match_revised) == 1:
             return match_revised[0]
-        return None
 
     return None
 

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -3,10 +3,9 @@ import os
 from dotenv import load_dotenv
 from typing import List
 
-from monkey_patch.monkey import Monkey as monkey
-
 load_dotenv()
 
+from monkey_patch.monkey import Monkey as monkey
 
 openai.api_key = os.getenv("OPENAI_API_KEY")
 
@@ -15,28 +14,40 @@ openai.api_key = os.getenv("OPENAI_API_KEY")
 def match_email(email: str, names: List[str]) -> str:
     """
     Examine the list of names and return the name that is most likely to correspond to the email address.
-    Return an empty string if no match is found.
+    The names array includes both first and last names. Make sure to consider both the first and last name
+    as unique values when searching for a match. If two names have the same score, return an empty string.
+    Return an empty string if no match is found or if more than one name could be an email match.
     """
+
 
 @monkey.align
 def align_match_email() -> None:
+
+    # 1:1 Matching
     assert match_email("john.smith@gmail.com", ["John Smith"]) == "John Smith"
+    assert match_email("jsmith@google.com", ["John Smith"]) == "John Smith"
+    assert match_email("j.smith@google.com", ["John Smith"]) == "John Smith"
+    assert match_email("jasmith@google.com", ["John Smith"]) == "John Smith"
 
+    # 1 from Many Matching
+    assert match_email("john.smith@gmail.com", ["John Smith", "Jen Smith"]) == "John Smith"
 
-@monkey.patch
-def summarize_text_extra(input: str, instructions: str) -> str:
-    """
-    Use the input argument and apply the instructions argument for how to assemble into response.
-    """
+    # Return None because there are multiple possible matches
+    assert match_email("jsmith@gmail.com", ["John Smith", "Jen Smith"]) == ""
+    assert match_email("johnsmith@gmail.com", ["John Smith", "John Smith Jr."]) == ""
+    assert match_email("johnsmith123@gmail.com", ["John Smith", "John Smith III"]) == ""
+    assert match_email("bill@example.net", ["Bill Burr", "Bill"]) == ""
+    assert match_email("smith@example.co", ["Smith Sanders", "Jen Smith", "Smit Harris"]) == ""
 
 
 # Example usage
 if __name__ == '__main__':
     print("Aligning...")
-    # align_match_email()
+    align_match_email()
 
     print("Matching...")
-    # match = match_email("ethan.brown@gmail.com", ["Ethan Brown", "John Smith", "Mary Johnson"])
-    # print(match)
-    print(openai.api_key)
-    summ = summarize_text_extra("This is a test", "Summarize the text")
+    match = match_email("ethan.brown@gmail.com", ["Ethan Brown", "John Smith", "Mary Johnson", "Eva Brown"])
+    print(match)
+
+    match = match_email("ebrown@gmail.com", ["Ethan Brown", "Eva Brown"])
+    print(match)

--- a/examples/email_matching/main.py
+++ b/examples/email_matching/main.py
@@ -39,11 +39,9 @@ def align_match_email() -> None:
     assert match_email("George@google.com", ["John Smith", "George Oakly", "George Bush", "Jaden Smith"]) == ["George Oakly", "George Bush"]
 
     # Return None because there are multiple possible matches
-    assert not match_email("jsmith@gmail.com", ["John Smith", "Jen Smith"])
-    assert not match_email("johnsmith@gmail.com", ["John Smith", "John Smith Jr."])
-    assert not match_email("johnsmith123@gmail.com", ["John Smith", "John Smith III"])
-    assert not match_email("bill@example.net", ["Bill Burr", "Bill"])
-    assert not match_email("smith@example.co", ["Smith Sanders", "Jen Smith", "Smit Harris"])
+    assert match_email("rsunak@gmail.com", ["John Smith", "Jen Smith", "Emily Johnson"]) == None
+    assert match_email("marcopolo@gmail.com", ["John Smith", "John Smith Jr.", "David Anderson"]) == None
+    assert match_email("johnsmith123@gmail.com", ["Lando Norrs", "David Singh"]) == None
 
 
 def wrap_match_email(email: str, names: List[str]) -> Optional[str]:

--- a/examples/email_matching/readme.md
+++ b/examples/email_matching/readme.md
@@ -6,7 +6,7 @@ Example use case is where a company has an email list of thousands of emails and
 
 ## Configuration
 
-You need to set the following environment variables:
+Set the following environment variables in your `.env` file:
 ```
 OPENAI_API_KEY=sk-XXX
 ```
@@ -26,5 +26,5 @@ pip install -r requirements.txt
 To align and test, run following command(s):
 ```
 python main.py
-ptest test_email_matching.py
+pytest -vv -s test_email_matching.py
 ```

--- a/examples/email_matching/readme.md
+++ b/examples/email_matching/readme.md
@@ -2,7 +2,7 @@
 
 This example replaces regex for matching an email to a list of names.
 
-For example, a company has an email list of thousands of emails and list of names in their database that aren't mapped
+Example use case is where a company has an email list of thousands of emails and list of names in their database that aren't mapped.
 
 ## Configuration
 
@@ -11,7 +11,7 @@ You need to set the following environment variables:
 OPENAI_API_KEY=sk-XXX
 ```
 
-Ensure you have an account with AWS for their email sending service, and OpenAI to access their underlying models.
+Ensure you have an account with OpenAI to access their underlying models.
 
 ## Install
 
@@ -23,7 +23,8 @@ pip install -r requirements.txt
 
 ## Usage
 
-Ensure that `run.sh` has sufficient permissions
-```bash
-chmod +x run_main.sh
+To align and test, run following command(s):
+```
+python main.py
+ptest test_email_matching.py
 ```

--- a/examples/email_matching/readme.md
+++ b/examples/email_matching/readme.md
@@ -1,0 +1,29 @@
+# Email-to-Name Matching
+
+This example replaces regex for matching an email to a list of names.
+
+For example, a company has an email list of thousands of emails and list of names in their database that aren't mapped
+
+## Configuration
+
+You need to set the following environment variables:
+```
+OPENAI_API_KEY=sk-XXX
+```
+
+Ensure you have an account with AWS for their email sending service, and OpenAI to access their underlying models.
+
+## Install
+
+```bash
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Usage
+
+Ensure that `run.sh` has sufficient permissions
+```bash
+chmod +x run_main.sh
+```

--- a/examples/email_matching/requirements.txt
+++ b/examples/email_matching/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv
+openai
+monkey-patch.py

--- a/examples/email_matching/requirements.txt
+++ b/examples/email_matching/requirements.txt
@@ -1,3 +1,4 @@
 python-dotenv
 openai
 monkey-patch.py
+pytest

--- a/examples/email_matching/test_email_matching.py
+++ b/examples/email_matching/test_email_matching.py
@@ -59,11 +59,11 @@ NAMES = [
 
 def test_match_email() -> None:
     assert match_email("ava.anderson@cool.com", ["Ava Anderson"]) == ["Ava Anderson"]
+    assert match_email("aanderson@cool.com", ["Ava Anderson", "Alan Anderson"]) == ["Ava Anderson", "Alan Anderson"]
 
 
 def test_match_email_none() -> None:
     assert not match_email("bob@cool.ai", ["Emily Johnson"])
-    assert not match_email("aanderson@cool.com", ["Ava Anderson", "Alan Anderson"])
 
 
 def test_wrap_match_email() -> None:

--- a/examples/email_matching/test_email_matching.py
+++ b/examples/email_matching/test_email_matching.py
@@ -1,4 +1,4 @@
-from main import match_email
+from main import match_email, wrap_match_email
 
 
 NAMES = [
@@ -58,18 +58,18 @@ NAMES = [
 
 
 def test_match_email() -> None:
-    assert match_email("ava.anderson@cool.com", ["Ava Anderson"]) == "Ava Anderson"
+    assert match_email("ava.anderson@cool.com", ["Ava Anderson"]) == ["Ava Anderson"]
 
 
 def test_match_email_none() -> None:
-    assert match_email("aanderson@cool.com", ["Ava Anderson", "Alan Anderson"]) == ""
-    assert match_email("bob@cool.ai", ["Emily Johnson"]) == ""
+    assert not match_email("bob@cool.ai", ["Emily Johnson"])
+    assert not match_email("aanderson@cool.com", ["Ava Anderson", "Alan Anderson"])
 
 
-def test_name_list() -> None:
-    assert match_email("eharris@example.ai", NAMES) == "Edward Harris"
-    assert match_email("sedward@example.com", NAMES) == "Sarah Edward"
-    assert match_email("l.davis@example.com", NAMES) == "Lisa Davis"
+def test_wrap_match_email() -> None:
+    assert wrap_match_email("eharris@example.ai", NAMES) == "Edward Harris"
+    assert wrap_match_email("sedward@example.com", NAMES) == "Sarah Edward"
+    assert wrap_match_email("l.davis@example.com", NAMES) == "Lisa Davis"
 
-    assert match_email("davis@example.com", NAMES) == ""
-    assert match_email("sarah@test.com", NAMES) == ""
+    assert not wrap_match_email("davis@example.com", NAMES)
+    assert not wrap_match_email("sarah@test.com", NAMES)

--- a/examples/email_matching/test_email_matching.py
+++ b/examples/email_matching/test_email_matching.py
@@ -71,5 +71,5 @@ def test_name_list() -> None:
     assert match_email("sedward@example.com", NAMES) == "Sarah Edward"
     assert match_email("l.davis@example.com", NAMES) == "Lisa Davis"
 
-    # assert match_email("davis@example.com", NAMES) == ""
-    # assert match_email("sarah@test.com", NAMES) == ""
+    assert match_email("davis@example.com", NAMES) == ""
+    assert match_email("sarah@test.com", NAMES) == ""

--- a/examples/email_matching/test_email_matching.py
+++ b/examples/email_matching/test_email_matching.py
@@ -1,0 +1,75 @@
+from main import match_email
+
+
+NAMES = [
+    "John Smith",
+    "Emily Johnson",
+    "Michael Davis",
+    "Sarah Wilson",
+    "Sarah Miller",
+    "David Anderson",
+    "Jennifer Brown",
+    "Robert Lee",
+    "Linda Taylor",
+    "William Jones",
+    "Mary Jackson",
+    "James White",
+    "Patricia Martinez",
+    "Daniel Wilson",
+    "Susan Clark",
+    "Joseph Garcia",
+    "Karen Harris",
+    "Richard Miller",
+    "Nancy Thomas",
+    "Charles Lewis",
+    "Jennifer Allen",
+    "Thomas Walker",
+    "Margaret Wright",
+    "Christopher Scott",
+    "Betty Hall",
+    "Daniel Moore",
+    "Dorothy King",
+    "Matthew Turner",
+    "Lisa Green",
+    "Donald Baker",
+    "Helen Adams",
+    "Mark Turner",
+    "Nancy Collins",
+    "Paul Davis",
+    "Sharon Edwards",
+    "George Taylor",
+    "Cynthia Martinez",
+    "Kenneth Jackson",
+    "Angela Clark",
+    "Steven Allen",
+    "Donna Miller",
+    "Edward Harris",
+    "Ruth Wilson",
+    "Brian Young",
+    "Deborah Martin",
+    "Ronald Anderson",
+    "Jessica Thompson",
+    "Gary Hernandez",
+    "Lisa Davis",
+    "Jerry Parker",
+    "Kimberly Johnson",
+    "Sarah Edward",
+]
+
+
+def test_match_email() -> None:
+    assert match_email("ava.anderson@cool.com", ["Ava Anderson"]) == "Ava Anderson"
+
+
+def test_match_email_none() -> None:
+    assert match_email("aanderson@cool.com", ["Ava Anderson", "Alan Anderson"]) == ""
+    assert match_email("bob@cool.ai", ["Emily Johnson"]) == ""
+
+
+def test_name_list() -> None:
+    assert match_email("eharris@example.ai", NAMES) == "Edward Harris"
+    assert match_email("sedward@example.com", NAMES) == "Sarah Edward"
+    assert match_email("l.davis@example.com", NAMES) == "Lisa Davis"
+
+    # assert match_email("davis@example.com", NAMES) == ""
+    # assert match_email("sarah@test.com", NAMES) == ""


### PR DESCRIPTION
This example replaces regex for matching an email to a list of names. Example use case is where a company has an email list of thousands of emails and list of names in their database that aren't mapped.