### PR TITLE
Enchancement/informative openai messages

### DIFF
--- a/src/monkey_patch/language_models/openai_api.py
+++ b/src/monkey_patch/language_models/openai_api.py
@@ -54,7 +54,7 @@ class Openai_API(LLM_Api):
         choice = None
         # initiate response so exception logic doesnt error out when checking for error in response
         response = {}
-        while counter < 5:
+        while counter <= 5:
             try:
                 openai_headers = {
                     "Authorization": f"Bearer {self.api_key}",
@@ -71,11 +71,10 @@ class Openai_API(LLM_Api):
                     "code" in response["error"] and 
                     response["error"]["code"] == 'invalid_api_key'):
                     raise Exception(f"The supplied OpenAI API key {self.api_key} is invalid")
-                
-                time.sleep(1 + 3 * counter)
-                counter += 1
                 if counter == 5:
                     raise Exception(f"OpenAI API failed to generate a response: {e}")
+                counter += 1
+                time.sleep(2 ** counter)
                 continue
         
         if not choice:

--- a/src/monkey_patch/language_models/openai_api.py
+++ b/src/monkey_patch/language_models/openai_api.py
@@ -66,7 +66,7 @@ class Openai_API(LLM_Api):
                 response = response.json()
                 choice = response["choices"][0]["message"]["content"].strip("'")
                 break
-            except Exception:
+            except Exception as e:
                 if ("error" in response and 
                     "code" in response["error"] and 
                     response["error"]["code"] == 'invalid_api_key'):
@@ -74,6 +74,8 @@ class Openai_API(LLM_Api):
                 
                 time.sleep(1 + 3 * counter)
                 counter += 1
+                if counter == 5:
+                    raise Exception(f"OpenAI API failed to generate a response: {e}")
                 continue
         
         if not choice:


### PR DESCRIPTION
2 improvements
1) If the openai api has retried 5 times, the final openai error message gets returned
2) Updated linear backoff to exponential backoff so per-minute rate-limits are also included in the backoff (total amount of backoff is greater than 60sec across 5 retries)
https://github.com/monkeypatch/monkeypatch.py/issues/78