### PR TITLE
fix: Fix author string in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 name = "monkey-patch.py"
 version = "0.0.5"
 description = "The easiest way to build scalable LLM-powered applications, which gets cheaper and faster over time."
-authors = ["Jack Hopkins <jack@paperplane.ai", "Mart Bakler <mart@paperplane.ai>"]
+authors = ["Jack Hopkins <jack@paperplane.ai>", "Mart Bakler <mart@paperplane.ai>"]
 
 [tool.poetry.dependencies]
 python = "^3.8"


### PR DESCRIPTION
This is a fairly trivial fix for the pyproject file.
While installing the project for local development I encountered the below error that I narrowed down to a missing closing `>` character. 
 
```
Installing the current project: monkey-patch.py (0.0.5)
Invalid author string. Must be in the format: John Smith <john@example.com>
```